### PR TITLE
fix graphite templates support

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -65,7 +65,11 @@ hostname = "<%= @hostname -%>"
   tags = [<% @graphite_tags.sort.map {|a| "\"#{a}\""}.join(',') -%>]
 <% end -%>
 <% if @graphite_templates and @graphite_templates.size > 0 -%>
-  tags = [<% @graphite_templates.sort.map {|a| "\"#{a}\""}.join(',') -%>]
+  templates = [
+  <%- @graphite_templates.each do |template| -%>
+    "<%= template %>",
+  <%- end -%>
+  ]
 <% end -%>
   ignore-unnamed = <%= @graphite_ignore_unnamed -%>
 


### PR DESCRIPTION
Fix text.
Change array processing syntax since previous one doesn't work (Puppet 3.7.5 on Debian Wheezy) 