### PR TITLE
Minor additions to module - meta_dir and influxd_opts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class influxdb::params {
   $commit_timeout                               = '50ms'
   $data_dir                                     = '/var/opt/influxdb/data'
   $wal_dir                                      = '/var/opt/influxdb/wal'
+  $meta_dir                                     = '/var/opt/influxdb/meta'
   $wal_enable_logging                           = true
   $wal_ready_series_size                        = 25600
   $wal_compaction_threshold                     = '0.6'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,7 @@ class influxdb::params {
   $enable_snapshot                              = false
   $influxdb_stderr_log                          = '/var/log/influxdb/influxd.log'
   $influxdb_stdout_log                          = '/dev/null'
+  $influxd_opts                                 = ''
   $manage_install                               = true
 
   case $::osfamily {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,6 +77,7 @@ class influxdb::server (
   $enable_snapshot                              = $influxdb::params::enable_snapshot,
   $influxdb_stderr_log                          = $influxdb::params::influxdb_stderr_log,
   $influxdb_stdout_log                          = $influxdb::params::influxdb_stdout_log,
+  $influxd_opts                                 = $influxdb::params::influxd_opts,
   $manage_install                               = $influxdb::params::manage_install,
 ) inherits influxdb::params {
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,6 +15,7 @@ class influxdb::server (
   $commit_timeout                               = $influxdb::params::commit_timeout,
   $data_dir                                     = $influxdb::params::data_dir,
   $wal_dir                                      = $influxdb::params::wal_dir,
+  $meta_dir                                     = $influxdb::params::meta_dir,
   $wal_enable_logging                           = $influxdb::params::wal_enable_logging,
   $wal_ready_series_size                        = $influxdb::params::wal_ready_series_size,
   $wal_compaction_threshold                     = $influxdb::params::wal_compaction_threshold,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -65,6 +65,7 @@ class influxdb::server::config {
   $enable_snapshot                              = $influxdb::server::enable_snapshot
   $influxdb_stderr_log                          = $influxdb::server::influxdb_stderr_log
   $influxdb_stdout_log                          = $influxdb::server::influxdb_stdout_log
+  $influxd_opts                                 = $influxdb::server::influxd_opts
 
   file { $config_file:
     ensure  => $ensure,

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -10,7 +10,7 @@ reporting-disabled = <%= @reporting_disabled %>
 ###
 [meta]
 
-  dir = "/var/opt/influxdb/meta"
+  dir = "<%= @meta_dir -%>"
 <% if @hostname -%>
 hostname = "<%= @hostname -%>"
 <% else -%>
@@ -141,4 +141,3 @@ hostname = "<%= @hostname -%>"
 [snapshot]
 enabled = <%= @enable_snapshot %>
 <% end -%>
-

--- a/templates/influxdb_default.erb
+++ b/templates/influxdb_default.erb
@@ -1,3 +1,3 @@
 STDERR=<%= @influxdb_stderr_log %>
 STDOUT=<%= @influxdb_stdout_log %>
-INFLUXD_OPTS=<%= @influxd_opts %>
+INFLUXD_OPTS="<%= @influxd_opts %>"

--- a/templates/influxdb_default.erb
+++ b/templates/influxdb_default.erb
@@ -1,2 +1,3 @@
 STDERR=<%= @influxdb_stderr_log %>
 STDOUT=<%= @influxdb_stdout_log %>
+INFLUXD_OPTS=<%= @influxd_opts %>


### PR DESCRIPTION
* meta_dir was hardcoded in config file.
* adding INFLUXD_OPTS to /etc/default/influxdb. This is needed in setting up raft clusters.