### PR TITLE
typesdb is mandatory when collectd is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ class {'influxdb::server':
   collectd_enabled      => true,
   collectd_bind_address => ':2004',
   collectd_database     => 'collectd',
+  collectd_typesdb      => '/usr/share/collectd/types.db',
 }
 ```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class influxdb::params {
   $collectd_enabled                             = false
   $collectd_bind_address                        = undef
   $collectd_database                            = undef
-  $collectd_typesdb                             = undef
+  $collectd_typesdb                             = '/usr/share/collectd/types.db'
   $opentsdb_enabled                             = false
   $opentsdb_bind_address                        = undef
   $opentsdb_database                            = undef


### PR DESCRIPTION
when enabling collectd but not providing `typesdb` influxdb fails to start with the following log:

```
[collectd] 2016/01/08 16:45:03 Starting collectd service
[copier] 2016/01/08 16:45:03 copier listener closed
[tcp] 2016/01/08 16:45:03 cluster service accept error: network connection closed
[snapshot] 2016/01/08 16:45:03 snapshot listener closed
[shard-precreation] 2016/01/08 16:45:03 Precreation service terminating
[continuous_querier] 2016/01/08 16:45:03 continuous query service terminating
[collectd] 2016/01/08 16:45:03 collectd UDP closed
[retention] 2016/01/08 16:45:03 retention policy enforcement terminating
[monitor] 2016/01/08 16:45:03 shutting down monitor system
[monitor] 2016/01/08 16:45:03 terminating storage of statistics
run: open server: open service: Open(): open : no such file or directory
```