### PR TITLE
Change package version to installed

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,6 @@
 class influxdb::server (
   $ensure                                       = $influxdb::params::ensure,
-  $version                                      = 'latest',
+  $version                                      = 'installed',
   $config_file                                  = $influxdb::params::config_file,
   $service_provider                             = $influxdb::params::service_provider,
   $service_enabled                              = $influxdb::params::service_enabled,


### PR DESCRIPTION
This was set to latest which is dangerous as a default as you usually don't want your influxdb upgraded automatically