### PR TITLE
Autodetect service provider

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,13 +92,6 @@ class influxdb::params {
     'Debian': {
       $influxdb_user    = 'influxdb'
       $influxdb_group   = 'influxdb'
-
-
-      if $::operatingsystem == 'Ubuntu' {
-        $service_provider = 'upstart'
-      } else {
-        $service_provider = undef
-      }
     }
     'RedHat', 'Amazon': {
       $influxdb_user    = 'influxdb'

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -5,12 +5,11 @@ class influxdb::server::service {
   } else {
     $service_ensure = 'stopped'
   }
-  
+
   service { 'influxdb':
     ensure     => $service_ensure,
     enable     => $influxdb::server::service_enabled,
     hasrestart => true,
-    provider   => $influxdb::server::service_provider,
     require    => Package['influxdb'],
   }
 


### PR DESCRIPTION
Remove forced service provider when using Ubuntu. This caused problems when I wanted to use it on Ubuntu 16.04, which supports upstart. Don't know why this was added because the documentation says:

> provider
> 
> The specific backend to use for this service resource. You will seldom need to specify this — Puppet will usually discover the appropriate provider for your platform.

Source: https://docs.puppet.com/puppet/latest/reference/type.html#service-attribute-provider 