### PR TITLE
enables the possibility to specify a custom service provider

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,6 +88,7 @@ class influxdb::params {
   $continuous_queries_enabled                   = true
   $continuous_queries_log_enabled               = true
   $continuous_queries_run_interval              = undef
+  $service_provider = undef
 
   case $::osfamily {
     'Debian': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -87,7 +87,8 @@ class influxdb::server (
 
   $continuous_queries_enabled                   = $influxdb::params::continuous_queries_enabled,
   $continuous_queries_log_enabled               = $influxdb::params::continuous_queries_log_enabled,
-  $continuous_queries_run_interval              = $influxdb::params::continuous_queries_run_interval
+  $continuous_queries_run_interval              = $influxdb::params::continuous_queries_run_interval,
+  $service_provider = $influxdb::params::service_provider
 ) inherits influxdb::params {
 
   anchor { 'influxdb::server::start': }->

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,6 +10,7 @@ class influxdb::server::service {
     ensure     => $service_ensure,
     enable     => $influxdb::server::service_enabled,
     hasrestart => true,
+    provider => $influxdb::server::service_provider,
     require    => Package['influxdb'],
   }
 


### PR DESCRIPTION
Useful for older versions of Puppet on systems with multiple init systems, where the default detected by puppet may not apply.
This is true for Puppet < 4 and Debian > 8 for example. 

Additionally, this behaviour is described in the documentation, but currently not implemented.
