### PR TITLE
add initial archlinux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,7 +97,8 @@ class influxdb::params {
       $manage_repos = false
     }
     default: {
-      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily RedHat, Debian and Archlinux")
+      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem},\
+      module ${module_name} currently only supports managing repos for osfamily RedHat, Debian and Archlinux")
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,6 @@ class influxdb::params {
   $influxdb_stdout_log                          = '/dev/null'
   $influxd_opts                                 = undef
   $manage_install                               = true
-  $manage_repos                                 = true
 
   $reporting_disabled                           = false
 
@@ -88,18 +87,17 @@ class influxdb::params {
   $continuous_queries_enabled                   = true
   $continuous_queries_log_enabled               = true
   $continuous_queries_run_interval              = undef
-
+  $influxdb_user                                = 'influxdb'
+  $influxdb_group                               = 'influxdb'
   case $::osfamily {
-    'Debian': {
-      $influxdb_user    = 'influxdb'
-      $influxdb_group   = 'influxdb'
+    'Debian', 'RedHat', 'Amazon': {
+      $manage_repos = true
     }
-    'RedHat', 'Amazon': {
-      $influxdb_user    = 'influxdb'
-      $influxdb_group   = 'influxdb'
+    'Archlinux': {
+      $manage_repos = false
     }
     default: {
-      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily RedHat and Debian")
+      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily RedHat, Debian and Archlinux")
     }
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -8,7 +8,8 @@ class influxdb::repo {
       class { 'influxdb::repo::yum': }
     }
     default: {
-      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily RedHat and Debian")
+      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem},\
+      module ${module_name} currently only supports managing repos for osfamily RedHat and Debian")
     }
   }
 }


### PR DESCRIPTION
I tested this on my own Arch box. I only needed to restructure the params.pp to make it work. I'm happily using this profile:

```puppet
class {'::influxdb::server':
  reporting_disabled  => false,
  collectd_options    => {
    enabled       => true,
    bind-address  => ':25826',
    database      => 'collectd_db',
    typesdb       => '/usr/share/collectd/types.db',
    batch-size    => 1000,
    batch-pending => 5,
    batch-timeout => '1s',
    read-buffer   => 0,
  },  
}
```