### PR TITLE
Add service_provider parameter back

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class influxdb::params {
   $version                                      = 'installed'
   $ensure                                       = 'present'
   $service_enabled                              = true
+  $service_provider                             = 'systemd'
   $conf_template                                = 'influxdb/influxdb.conf.erb'
   $config_file                                  = '/etc/influxdb/influxdb.conf'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,6 +2,7 @@ class influxdb::server (
   $version                                      = $influxdb::params::version,
   $ensure                                       = $influxdb::params::ensure,
   $service_enabled                              = $influxdb::params::service_enabled,
+  $service_provider                             = $influxdb::params::service_provider,
   $conf_template                                = $influxdb::params::conf_template,
   $config_file                                  = $influxdb::params::config_file,
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,6 +10,7 @@ class influxdb::server::service {
     ensure     => $service_ensure,
     enable     => $influxdb::server::service_enabled,
     hasrestart => true,
+    provider   => $influxdb::server::service_provider,
     require    => Package['influxdb'],
   }
 


### PR DESCRIPTION
For some reason, Puppet won't detect systemd as default service provider on Debian, failing with this error : 
`Error: /Stage[main]/Influxdb::Server::Service/Service[influxdb]: Could not evaluate: Could not find init script for 'influxdb'`

This commit is kind of a revert of #37 
