### PR TITLE
Add support for parameter max-series-per-database

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Default true
 
 Default: 1s
 
+##### `max_series_per_database`
+
+Controls the number of series allowed per database. Change the setting
+to 0 to allow an unlimited number of series per database.
+Default: 1000000
+
 ##### `hinted_handoff_enabled`
 
 Controls the hinted handoff feature, which allows nodes to temporarily

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class influxdb::params {
   $compact_min_file_count                       = undef
   $compact_full_write_cold_duration             = undef
   $max_points_per_block                         = undef
+  $max_series_per_database                      = 1000000
 
   $hinted_handoff_enabled                       = true
   $hinted_handoff_dir                           = '/var/lib/influxdb/hh'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -34,6 +34,7 @@ class influxdb::server (
   $compact_min_file_count                       = $influxdb::params::compact_min_file_count,
   $compact_full_write_cold_duration             = $influxdb::params::compact_full_write_cold_duration,
   $max_points_per_block                         = $influxdb::params::max_points_per_block,
+  $max_series_per_database                      = $influxdb::params::max_series_per_database,
 
   $hinted_handoff_enabled                       = $influxdb::params::hinted_handoff_enabled,
   $hinted_handoff_dir                           = $influxdb::params::hinted_handoff_dir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -37,6 +37,7 @@ class influxdb::server::config {
   $compact_min_file_count                       = $influxdb::server::compact_min_file_count
   $compact_full_write_cold_duration             = $influxdb::server::compact_full_write_cold_duration
   $max_points_per_block                         = $influxdb::server::max_points_per_block
+  $max_series_per_database                      = $influxdb::server::max_series_per_database
 
   $hinted_handoff_enabled                       = $influxdb::server::hinted_handoff_enabled
   $hinted_handoff_dir                           = $influxdb::server::hinted_handoff_dir

--- a/spec/classes/config_template_spec.rb
+++ b/spec/classes/config_template_spec.rb
@@ -31,6 +31,7 @@ describe 'influxdb::server', :type => :class do
     'monitoring_database' => '_internal',
     'monitoring_write_interval' => '24h',
     'continuous_queries_enabled' => true,
+    'max_series_per_database' => 1000000,
     'hinted_handoff_enabled' => true,
     'hinted_handoff_dir' => '/var/opt/influxdb/hh',
     'hinted_handoff_max_size' => 1073741824,

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -42,6 +42,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% if @max_points_per_block -%>
   max-points-per-block = <%= @max_points_per_block %>
 <% end -%>
+  max-series-per-database = <%= @max_series_per_database %>
 
 [hinted-handoff]
   enabled = <%= @hinted_handoff_enabled %>


### PR DESCRIPTION
According to the [changelog](https://github.com/influxdata/influxdb/blob/v1.0.0/CHANGELOG.md) they added the parameter _max-series-per-database_ with a default of 1M. This patch should allow the user to disable this limitation, by setting _max-series-per-database_ to 0.