### PR TITLE
Update rspec-puppet-facts to fix tests on puppet 4.X versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :test do
   gem 'json_pure','~> 1.8',     :require => false
   gem 'json',                   :require => false
   gem 'metadata-json-lint',     :require => false
-  gem 'rspec-puppet-facts', '~> 0.10'
+  gem 'rspec-puppet-facts',     :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
On puppet versions > 4.0 the puppetversion fact is missing on some operatingsystem modes causing tests to fail because of a failure to evaluate the variable within the puppetlabs-apt module.  This PR updates the rspec-puppet-facts gem to 1.7.0 (currently... it actually just changes it to use the latest) which seems to have resolves this.