### PR TITLE
Adding apt-get update step before package declaration since a clean …

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -14,5 +14,9 @@ class influxdb::repo::apt {
     include_src => false,
   }
 
-  Apt::Source['repos.influxdata.com'] -> Package<| tag == 'influxdb' |>
+  exec { "apt-update":
+      command => "/usr/bin/apt-get update"
+  }
+
+  Apt::Source['repos.influxdata.com'] -> Exec["apt-update"] -> Package<| tag == 'influxdb' |>
 }


### PR DESCRIPTION
…install of influxdb on 14.04.5 LTS Ubuntu using vagrant produces the following error: "==> default: Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install influxdb' returned 100: Reading package lists..."

Based on: http://stackoverflow.com/a/13655214/604048
