### PR TITLE
Add support for parameter max-values-per-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,12 @@ Controls the number of series allowed per database. Change the setting
 to 0 to allow an unlimited number of series per database.
 Default: 1000000
 
+##### `max_values_per_tag`
+
+Controls the number of tag values allowed per tag key. Change the setting
+ to 0 to allow an unlimited number of tag values per tag key.
+Default: 100000
+
 ##### `hinted_handoff_enabled`
 
 Controls the hinted handoff feature, which allows nodes to temporarily

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class influxdb::params {
   $compact_full_write_cold_duration             = undef
   $max_points_per_block                         = undef
   $max_series_per_database                      = 1000000
+  $max_values_per_tag                           = 100000
 
   $hinted_handoff_enabled                       = true
   $hinted_handoff_dir                           = '/var/lib/influxdb/hh'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -35,6 +35,7 @@ class influxdb::server (
   $compact_full_write_cold_duration             = $influxdb::params::compact_full_write_cold_duration,
   $max_points_per_block                         = $influxdb::params::max_points_per_block,
   $max_series_per_database                      = $influxdb::params::max_series_per_database,
+  $max_values_per_tag                           = $influxdb::params::max_values_per_tag,
 
   $hinted_handoff_enabled                       = $influxdb::params::hinted_handoff_enabled,
   $hinted_handoff_dir                           = $influxdb::params::hinted_handoff_dir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -38,6 +38,7 @@ class influxdb::server::config {
   $compact_full_write_cold_duration             = $influxdb::server::compact_full_write_cold_duration
   $max_points_per_block                         = $influxdb::server::max_points_per_block
   $max_series_per_database                      = $influxdb::server::max_series_per_database
+  $max_values_per_tag                           = $influxdb::server::max_values_per_tag
 
   $hinted_handoff_enabled                       = $influxdb::server::hinted_handoff_enabled
   $hinted_handoff_dir                           = $influxdb::server::hinted_handoff_dir

--- a/spec/classes/config_template_spec.rb
+++ b/spec/classes/config_template_spec.rb
@@ -32,6 +32,7 @@ describe 'influxdb::server', :type => :class do
     'monitoring_write_interval' => '24h',
     'continuous_queries_enabled' => true,
     'max_series_per_database' => 1000000,
+    'max_values_per_tag' => 100000,
     'hinted_handoff_enabled' => true,
     'hinted_handoff_dir' => '/var/opt/influxdb/hh',
     'hinted_handoff_max_size' => 1073741824,

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -43,6 +43,7 @@ reporting-disabled = <%= @reporting_disabled %>
   max-points-per-block = <%= @max_points_per_block %>
 <% end -%>
   max-series-per-database = <%= @max_series_per_database %>
+  max-values-per-tag = <%= @max_values_per_tag %>
 
 [hinted-handoff]
   enabled = <%= @hinted_handoff_enabled %>


### PR DESCRIPTION
According to the [changelog](https://github.com/influxdata/influxdb/blob/1.1/CHANGELOG.md#data-section) they added the parameter max-values-per-tag with a default of 100000. This patch should allow the user to disable this limitation, by setting max-values-per-tag to 0.