### PR TITLE
Increase puppetlabs-apt compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0 <4.13.0"
+      "version_requirement": ">= 1.0.0 <5.0.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.8.0 <3.0.0"
+      "version_requirement": ">=1.8.0 <5.0.0"
     }
   ]
 }


### PR DESCRIPTION
This PR increases compatibility for the dependency 'puppetlabs-apt'. 

There is no reason to limit compatibility to ::apt because the apt::source definition is very simple and compatible to latest versions of the apt module. 

