### PR TITLE
Add FreeBSD platform support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 class influxdb::config(
   $conf                      = $influxdb::config_file,
   $conf_owner                = 'root',
-  $conf_group                = 'root',
+  $conf_group                = $influxdb::config_group,
   $conf_mode                 = '0644',
   $conf_template             = $influxdb::conf_template,
 
@@ -33,7 +33,7 @@ class influxdb::config(
 ) {
 
   $notify = $influxdb::manage_service ? {
-    true => Service['influxdb'],
+    true => Service[$influxdb::service_name],
     false => undef,
     default => undef,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class influxdb(
   $manage_service            = $influxdb::params::manage_service,
   $conf_template             = $influxdb::params::conf_template,
   $config_file               = $influxdb::params::config_file,
+  $config_group              = $influxdb::params::config_group,
 
   $global_config             = $influxdb::params::global_config,
   $meta_config               = $influxdb::params::meta_config,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,12 +2,13 @@
 class influxdb::service(
   $service_ensure  = $influxdb::service_ensure,
   $service_enabled = $influxdb::service_enabled,
+  $service_name    = $influxdb::service_name,
   $manage_service  = $influxdb::manage_service,
 ){
 
   if $manage_service {
 
-    service { 'influxdb':
+    service { $service_name:
       ensure     => $service_ensure,
       enable     => $service_enabled,
       hasrestart => true,


### PR DESCRIPTION
Some parameters are specific to FreeBSD, for example:
  - all configuration files are in /usr/local prefix;
  - InfluxDB data directory: /var/db/influxdb;
  - name of the service: influxd;

Therefore added these parameters as variables for
 greater flexibility of the module.

Tested on: FreeBSD 12.0-RELEASE, FreeBSD 13-CURRENT